### PR TITLE
Sub header to news page now not repeated

### DIFF
--- a/inc/acf_fields/news.php
+++ b/inc/acf_fields/news.php
@@ -1,5 +1,8 @@
 <?php 
 
+
+
+
 acf_add_local_field_group(array(
 	'key' => 'group_60f6d79326a5a',
 	'title' => 'News',
@@ -181,6 +184,52 @@ acf_add_local_field_group(array(
 	),
 	'menu_order' => 0,
 	'position' => 'normal',
+	'style' => 'default',
+	'label_placement' => 'top',
+	'instruction_placement' => 'label',
+	'hide_on_screen' => '',
+	'active' => true,
+	'description' => '',
+	'show_in_rest' => 0,
+));
+
+
+acf_add_local_field_group(array(
+	'key' => 'group_641c24f6b037e',
+	'title' => 'News sub header',
+	'fields' => array(
+		array(
+			'key' => 'subheaderarticle',
+			'label' => 'Article sub header',
+			'name' => 'subheaderarticle',
+			'aria-label' => '',
+			'type' => 'text',
+			'instructions' => '',
+			'required' => 0,
+			'conditional_logic' => 0,
+			'wrapper' => array(
+				'width' => '',
+				'class' => '',
+				'id' => '',
+			),
+			'default_value' => '',
+			'maxlength' => '',
+			'placeholder' => '',
+			'prepend' => '',
+			'append' => '',
+		),
+	),
+	'location' => array(
+		array(
+			array(
+				'param' => 'post_type',
+				'operator' => '==',
+				'value' => 'post',
+			),
+		),
+	),
+	'menu_order' => 0,
+	'position' => 'acf_after_title',
 	'style' => 'default',
 	'label_placement' => 'top',
 	'instruction_placement' => 'label',

--- a/single.php
+++ b/single.php
@@ -12,12 +12,18 @@ $thumbnail= get_field('thumbnail'); ?>
 
 	<div class="container newsevents">
 	  	<div class="row">
-
 			<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
 
 		        <div class="col-12 col-md-8 single-content standard-content">
-					<h2 class="heading-two"><?php the_title(); ?></h2>
-					<div class="gradline"></div>
+
+					<?php if( get_field('subheaderarticle') ): ?>
+						<h2 class="heading-two"><?php the_field('subheaderarticle'); ?></h2>
+						<div class="gradline"></div>
+					<?php else: ?>
+						<div class="gradline mt-0"></div>
+					<?php endif; ?>
+
+
 					<p class="body-text"></p>
 		          	<?php the_content(); ?>
 					  <?php if (has_category('newsletter') || has_category('the-fountain')) : get_template_part('template-parts/content-newsletters'); endif; ?>


### PR DESCRIPTION
added acf field to news & events to only appear on posts pages - this will only show up on the news page if not empty